### PR TITLE
chore(ENG-11425): replace semantic-release PAT with GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,26 +10,33 @@ jobs:
     environment: PROD
 
     steps:
-      - name: "Checkout repo"
-        uses: actions/checkout@v4
+      - name: Mint semantic-release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          token: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
+          app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
+
+      - name: "Checkout repo"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Start Deploy Message
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "yarn"
 
       # Set up Python 3
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
 
@@ -47,7 +54,7 @@ jobs:
 
       - name: "Release"
         env:
-          GH_TOKEN: ${{ secrets.GH_SEMANTIC_RELEASE_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: |
           yarn install --frozen-lockfile
@@ -55,7 +62,7 @@ jobs:
 
       - name: Stop Deploy Message
         if: always()
-        uses: Basis-Theory/public-github-actions/deploy-slack-action@master
+        uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:
           slack-api-token: ${{ secrets.SLACK_DUCKBOT_API_KEY }}
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,14 @@ jobs:
         with:
           app-id: ${{ vars.SEMANTIC_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMANTIC_RELEASE_APP_PRIVATE_KEY }}
-
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
       - name: "Checkout repo"
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-
+          persist-credentials: false
       - name: Start Deploy Message
         uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:


### PR DESCRIPTION
## Description
- Replace the `GH_SEMANTIC_RELEASE_PAT` in the release workflow with a short-lived `bt_semantic_release` GitHub App token (minted via `actions/create-github-app-token`), used for both the checkout and the semantic-release GitHub/git operations (`GH_TOKEN`).
- Pin all actions in the touched workflow to commit SHAs.
- Part of ENG-11425 (semantic-release PAT → GitHub App migration). The `SEMANTIC_RELEASE_APP_PRIVATE_KEY` secret is provisioned separately in github-repository-management (master-restricted prod env).

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change