### PR TITLE
test: accept updated Google Pay processing-failure error message

### DIFF
--- a/tests/custom/test_client.py
+++ b/tests/custom/test_client.py
@@ -472,7 +472,13 @@ def test_should_support_google_pay() -> None:
         )
         assert False, "Should have thrown an error"
     except UnprocessableEntityError as e:
-        assert "Failed to decrypt Google payment request" in e.body.detail, "The error detail does not contain the expected message."
+        assert any(
+            msg in e.body.detail
+            for msg in (
+                "Failed to decrypt Google payment request",
+                "Failed to process the Google Pay token",
+            )
+        ), "The error detail does not contain an expected Google Pay processing-failure message."
 
 
 def test_documents_lifecycle() -> None:


### PR DESCRIPTION
## Description
- The Google Pay error-handling integration test asserted a single hardcoded detail string (`"Failed to decrypt Google payment request"`), but the dev API now returns `"Failed to process the Google Pay token; the token payload is invalid or malformed."`, failing the `test` check.
- Make the assertion accept either the old or the new message so it's resilient to the API's error-copy wording.
- Surfaced while validating the ENG-11425 semantic-release migration; the stale assertion is pre-existing and unrelated to that token change.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change