### PR TITLE
fix: keep persisted app-token creds for semantic-release write-back

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
       - name: Start Deploy Message
         uses: Basis-Theory/public-github-actions/deploy-slack-action@12362db6b1ad6b524d28c47a6489c3e73ecd656a # master
         with:


### PR DESCRIPTION
## Description
- Remove `persist-credentials: false` from the release checkout. semantic-release performs its own `git push` for the version/changelog write-back and relies on the credential `actions/checkout` persists (the `x-access-token` extraheader). With `persist-credentials: false`, semantic-release fell back to embedding the token in the push URL, which GitHub rejects for GitHub App installation tokens — failing with `Invalid username or token. Password authentication is not supported` → `EGITNOPERMISSION`.
- Using the checkout default (`persist-credentials: true`) is the standard, working setup for semantic-release + a GitHub App token. The app-token scopes issue was fixed separately (bt-semantic-release granted issues/pull-requests: write).
- Fixes the release that broke after merging the ENG-11425 migration.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change